### PR TITLE
Ajout de 10 ans dans le to (Pour le filtre de calcul de temps)

### DIFF
--- a/API/repositories/project_repository.go
+++ b/API/repositories/project_repository.go
@@ -64,6 +64,7 @@ func GetProjects() ([]*DAOs.Project, error) {
 }
 
 func fixFromAndToTime(from string, to string) (string, string) {
+	//Le AddDate ajoute 10 ans.
 	year, month, day := time.Now().AddDate(10, 0, 0).Date()
 
 	toDate := ""


### PR DESCRIPTION
# Description

J'ai ajouter 10 ans pour fixer un bug dans le filtre de calcul de temps

## Qualité du code

- [X] Les noms des variables, fonctions et classes sont descriptifs et suivent les conventions de nommage du projet. Ex: `calculateTotalPrice()` vs `calc()` ou `userFirstName` vs `ufn`.
- [X] Le code qui se répète doit être groupé à un endroit pour être réutilisé facilement.

## Tests

- [X] Les tests testent les cas valides
- [X] Les tests testent tous les cas fautifs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de mise à jour

* **Modifications**
  * Les plages de dates par défaut pour les requêtes ont été mises à jour. La période s'étend maintenant 10 années à partir de la date actuelle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->