### PR TITLE
Excel : ajout du statut de projet et conversion de l'heure UTC -> local

### DIFF
--- a/API/controllers/handler_errors_controller.go
+++ b/API/controllers/handler_errors_controller.go
@@ -20,7 +20,7 @@ func handleError(ctx *gin.Context, err error, subject string) {
 		errorMsg := fmt.Sprintf("La catégorie a une ou des activités associées, suppression impossible")
 		log.Printf("ERREUR - Suppression impossible: %s - %v", errorMsg, err)
 		ctx.JSON(http.StatusBadRequest, gin.H{"error": errorMsg})
-		
+
 	case customs_errors.ErrNotFound:
 		errorMsg := fmt.Sprintf("Le(La) %s n'a pas été trouvé(e)", subject)
 		log.Printf("ERREUR - Ressource non trouvée: %s - %v", errorMsg, err)
@@ -83,6 +83,11 @@ func handleError(ctx *gin.Context, err error, subject string) {
 	case customs_errors.ErrProjectCouldntModifyArchive:
 		errorMsg := fmt.Sprintf("Impossible d'archiver le projet, il y a eu une erreur avec la base de données")
 		log.Printf("ERREUR - impossible d'archiver le projet, il y a eu une erreur avec la base de données: %s - %v", errorMsg, err)
+		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errorMsg})
+
+	case customs_errors.ErrCantLoadLocalTimezone:
+		errorMsg := fmt.Sprintf("Impossible d'effectuer cette action, car il y a eu une erreur serveur à l'obtention du fuseau horaire.")
+		log.Printf("ERREUR SERVEUR - impossible d'obtenir le fuseau horaire local, vérifiez le nom du fuseau fourni ou faites import _ \"time/tzdata\" au dessus du fichier l'utilisant : %s - %v", errorMsg, err)
 		ctx.JSON(http.StatusInternalServerError, gin.H{"error": errorMsg})
 
 	default:

--- a/API/customs_errors/customs_errors.go
+++ b/API/customs_errors/customs_errors.go
@@ -23,4 +23,5 @@ var (
 	ErrCantGetProjects             = errors.New("Erreur - Impossible de récupérer les projets")
 	ErrInvalidRequest              = errors.New("requête invalide")
 	ErrSelectedUserIsNotCoManager  = errors.New("l'utilisateur sélectionné n'est pas co-chargé de ce projet")
+	ErrCantLoadLocalTimezone       = errors.New("erreur système - impossible d'obtenir le fuseau horaire local")
 )

--- a/API/services/report_service.go
+++ b/API/services/report_service.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"llio-api/models/enums"
 	"llio-api/repositories"
+	"time"
 
 	"github.com/xuri/excelize/v2"
 )
@@ -13,6 +14,11 @@ func GenerateExcel(w io.Writer) error {
 	activities, err := repositories.GetAllForExport()
 	if err != nil {
 		return fmt.Errorf("failed to fetch activities: %w", err)
+	}
+
+	loc, err := time.LoadLocation("America/Toronto")
+	if err != nil {
+		return fmt.Errorf("failed to load timezone: %w", err)
 	}
 
 	f := excelize.NewFile()
@@ -48,8 +54,8 @@ func GenerateExcel(w io.Writer) error {
 		f.SetCellValue(sheet, fmt.Sprintf("F%d", row), a.Name)
 		f.SetCellValue(sheet, fmt.Sprintf("G%d", row), a.Category.Name)
 
-		f.SetCellValue(sheet, fmt.Sprintf("H%d", row), a.StartDate.Format("2006-01-02 15:04"))
-		f.SetCellValue(sheet, fmt.Sprintf("I%d", row), a.EndDate.Format("2006-01-02 15:04"))
+		f.SetCellValue(sheet, fmt.Sprintf("H%d", row), a.StartDate.In(loc).Format("2006-01-02 15:04"))
+		f.SetCellValue(sheet, fmt.Sprintf("I%d", row), a.EndDate.In(loc).Format("2006-01-02 15:04"))
 		f.SetCellValue(sheet, fmt.Sprintf("J%d", row), a.TimeSpent)
 
 		row++

--- a/API/services/report_service.go
+++ b/API/services/report_service.go
@@ -3,6 +3,7 @@ package services
 import (
 	"fmt"
 	"io"
+	"llio-api/customs_errors"
 	"llio-api/models/enums"
 	"llio-api/repositories"
 	"time"
@@ -18,7 +19,7 @@ func GenerateExcel(w io.Writer) error {
 
 	loc, err := time.LoadLocation("America/Toronto")
 	if err != nil {
-		return fmt.Errorf("failed to load timezone: %w", err)
+		return customs_errors.ErrCantLoadLocalTimezone
 	}
 
 	f := excelize.NewFile()

--- a/API/services/report_service.go
+++ b/API/services/report_service.go
@@ -39,9 +39,20 @@ func GenerateExcel(w io.Writer) error {
 	row := 2
 
 	for _, a := range activities {
-		status := "actif"
-		if a.Project.Status == enums.ProjectStatus(enums.Archived) {
+		status := "inconnu"
+
+		switch a.Project.Status {
+		case enums.ProjectStatus(enums.Archived):
 			status = "archivé"
+
+		case enums.ProjectStatus(enums.InProgress):
+			status = "actif"
+
+		case enums.ProjectStatus(enums.NotStart):
+			status = "non-démarré"
+
+		case enums.ProjectStatus(enums.Cancel):
+			status = "annulé"
 		}
 
 		f.SetCellValue(sheet, fmt.Sprintf("A%d", row), a.User.FirstName)

--- a/API/services/report_service.go
+++ b/API/services/report_service.go
@@ -3,25 +3,26 @@ package services
 import (
 	"fmt"
 	"io"
+	"llio-api/models/enums"
 	"llio-api/repositories"
 
 	"github.com/xuri/excelize/v2"
 )
 
 func GenerateExcel(w io.Writer) error {
-    activities, err := repositories.GetAllForExport()
-    if err != nil {
-        return fmt.Errorf("failed to fetch activities: %w", err)
-    }
+	activities, err := repositories.GetAllForExport()
+	if err != nil {
+		return fmt.Errorf("failed to fetch activities: %w", err)
+	}
 
 	f := excelize.NewFile()
 	sheet := "Sheet1"
 
 	headers := []string{
 		"Prénom", "Nom",
-		"Projet", "Unique ID",
+		"Projet", "Unique ID", "Statut du projet",
 		"Activité", "Catégorie",
-		"Date de début", "Date de fin","Temps passé (h)",
+		"Date de début", "Date de fin", "Temps passé (h)",
 	}
 
 	for i, h := range headers {
@@ -32,18 +33,24 @@ func GenerateExcel(w io.Writer) error {
 	row := 2
 
 	for _, a := range activities {
+		status := "actif"
+		if a.Project.Status == enums.ProjectStatus(enums.Archived) {
+			status = "archivé"
+		}
+
 		f.SetCellValue(sheet, fmt.Sprintf("A%d", row), a.User.FirstName)
 		f.SetCellValue(sheet, fmt.Sprintf("B%d", row), a.User.LastName)
 
 		f.SetCellValue(sheet, fmt.Sprintf("C%d", row), a.Project.Name)
 		f.SetCellValue(sheet, fmt.Sprintf("D%d", row), a.Project.UniqueId)
+		f.SetCellValue(sheet, fmt.Sprintf("E%d", row), status)
 
-		f.SetCellValue(sheet, fmt.Sprintf("E%d", row), a.Name)
-		f.SetCellValue(sheet, fmt.Sprintf("F%d", row), a.Category.Name)
+		f.SetCellValue(sheet, fmt.Sprintf("F%d", row), a.Name)
+		f.SetCellValue(sheet, fmt.Sprintf("G%d", row), a.Category.Name)
 
-		f.SetCellValue(sheet, fmt.Sprintf("G%d", row), a.StartDate.Format("2006-01-02 15:04"))
-		f.SetCellValue(sheet, fmt.Sprintf("H%d", row), a.EndDate.Format("2006-01-02 15:04"))
-        f.SetCellValue(sheet, fmt.Sprintf("I%d", row), a.TimeSpent)
+		f.SetCellValue(sheet, fmt.Sprintf("H%d", row), a.StartDate.Format("2006-01-02 15:04"))
+		f.SetCellValue(sheet, fmt.Sprintf("I%d", row), a.EndDate.Format("2006-01-02 15:04"))
+		f.SetCellValue(sheet, fmt.Sprintf("J%d", row), a.TimeSpent)
 
 		row++
 	}

--- a/API/useful/date_utils.go
+++ b/API/useful/date_utils.go
@@ -1,7 +1,7 @@
 package useful
 
 import (
-	"fmt"
+	"llio-api/customs_errors"
 	"time"
 )
 
@@ -24,7 +24,7 @@ func ToEndOfDay(date time.Time) time.Time {
 func AsTorontoThenUTC(date time.Time) (time.Time, error) {
 	loc, err := time.LoadLocation("America/Toronto")
 	if err != nil {
-		return time.Time{}, fmt.Errorf("failed to load timezone: %w", err)
+		return time.Time{}, customs_errors.ErrCantLoadLocalTimezone
 	}
 
 	// Reprends les mêmes chiffres que la date originale, mais lui applique le fuseau horaire America/Toronto plutôt que


### PR DESCRIPTION
# Description

Ce code mets l'heure dans les exports Excel en temps local (toujours `America/Toronto`) et ajoute le champ du statut de projet.

closes #337 
fixes #335 

----

Liste à cocher pour t'aider à faire une revue de code efficace.

## Qualité du code

- [ ] Les noms des variables, fonctions et classes sont descriptifs et suivent les conventions de nommage du projet. Ex: `calculateTotalPrice()` vs `calc()` ou `userFirstName` vs `ufn`.
- [ ] Le code qui se répète doit être groupé à un endroit pour être réutilisé facilement.

## Tests

- [ ] Les tests testent les cas valides
- [ ] Les tests testent tous les cas fautifs

## Documentation

- [ ] La documentation a été mise à jour si nécessaire

## Gestion des erreurs

- [ ] On gère toutes les erreurs. Ex: (pas de `catch` vide ou de `return;` en cas d'erreur)
- [ ] On utilise le logger pour journaliser les erreurs

## Quand tu as terminé

lancer coderabbitai en ajoutant `@Coderabbitai` dans ta revue de code. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nouvelles fonctionnalités**
  * Ajout d'une colonne "Statut du projet" dans les rapports Excel générés pour afficher clairement l'état des projets.
  * Amélioration du formatage des dates de début et fin grâce à une conversion de fuseau horaire pour assurer une meilleure précision temporelle.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecoleduweb/GestionnaireHoraireLLIO/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->