### PR TITLE
Fix du problème de fuseaux horaires à l'import Outlook

### DIFF
--- a/API/services/graph_api_service.go
+++ b/API/services/graph_api_service.go
@@ -14,11 +14,22 @@ const GraphApiBaseUrl = "https://graph.microsoft.com/v1.0"
 func GetCalendarEvents(accessToken string, date time.Time) ([]DTOs.GraphEvent, error) {
 	startOfDay := useful.ToStartOfDay(date)
 	endOfDay := useful.ToEndOfDay(date)
+
+	startOfDayUTC, err := useful.AsTorontoThenUTC(startOfDay)
+	if err != nil {
+		return nil, err
+	}
+
+	endOfDayUTC, err := useful.AsTorontoThenUTC(endOfDay)
+	if err != nil {
+		return nil, err
+	}
+
 	url := fmt.Sprintf(
 		"%s/me/calendarView?startDateTime=%s&endDateTime=%s",
 		GraphApiBaseUrl,
-		useful.DateToISOString(startOfDay),
-		useful.DateToISOString(endOfDay),
+		useful.DateToISOString(startOfDayUTC),
+		useful.DateToISOString(endOfDayUTC),
 	)
 
 	body, err := GraphApiGetRequest(url, accessToken)

--- a/API/useful/date_utils.go
+++ b/API/useful/date_utils.go
@@ -1,6 +1,9 @@
 package useful
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
 // DateToISOString Formatter la date dans le format RFC3339 (YYYY-MM-DDThh:mm:ssZ), notamment utile pour l'API Outlook.
 func DateToISOString(date time.Time) string {
@@ -13,4 +16,24 @@ func ToStartOfDay(date time.Time) time.Time {
 
 func ToEndOfDay(date time.Time) time.Time {
 	return time.Date(date.Year(), date.Month(), date.Day(), 23, 59, 59, 0, date.Location())
+}
+
+// AsTorontoThenUTC prends une heure existante, peu importe son fuseau horaire, et la considère comme étant du fuseau
+// horaire local. Elle la reconverti alors en heure UTC, ce qui peut être utile pour certains services externes comme
+// Graph API.
+func AsTorontoThenUTC(date time.Time) (time.Time, error) {
+	loc, err := time.LoadLocation("America/Toronto")
+	if err != nil {
+		return time.Time{}, fmt.Errorf("failed to load timezone: %w", err)
+	}
+
+	// Reprends les mêmes chiffres que la date originale, mais lui applique le fuseau horaire America/Toronto plutôt que
+	// celui existant/celui du serveur
+	toronto := time.Date(
+		date.Year(), date.Month(), date.Day(),
+		date.Hour(), date.Minute(), date.Second(), date.Nanosecond(),
+		loc,
+	)
+
+	return toronto.UTC(), nil
 }


### PR DESCRIPTION
# Description

Ce code permet de convertir l'heure locale en UTC avant de la passer à Graph API, permettant d'avoir des journées de 00:00:00 à 23:59:59 plutôt que de 20:00:00 J-1 à 19:59:59.

fixes #336 

----

Liste à cocher pour t'aider à faire une revue de code efficace.

## Qualité du code

- [ ] Les noms des variables, fonctions et classes sont descriptifs et suivent les conventions de nommage du projet. Ex: `calculateTotalPrice()` vs `calc()` ou `userFirstName` vs `ufn`.
- [ ] Le code qui se répète doit être groupé à un endroit pour être réutilisé facilement.

## Tests

- [ ] Les tests testent les cas valides
- [ ] Les tests testent tous les cas fautifs

## Documentation

- [ ] La documentation a été mise à jour si nécessaire

## Gestion des erreurs

- [ ] On gère toutes les erreurs. Ex: (pas de `catch` vide ou de `return;` en cas d'erreur)
- [ ] On utilise le logger pour journaliser les erreurs

## Quand tu as terminé

lancer coderabbitai en ajoutant `@Coderabbitai` dans ta revue de code. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notes de version

* **Corrections de bogues**
  * Correction du traitement des fuseaux horaires pour les événements calendrier. Les heures locales sont maintenant correctement converties en UTC avant de récupérer les données du calendrier, assurant l'affichage précis des événements indépendamment de la région.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ecoleduweb/GestionnaireHoraireLLIO/pull/339?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->