### PR TITLE
Fix de la sélection automatique du projet

### DIFF
--- a/LLIO2025/src/Components/Calendar/OutlookImportModal.svelte
+++ b/LLIO2025/src/Components/Calendar/OutlookImportModal.svelte
@@ -28,7 +28,7 @@
 
     let selectedEventInt = $state<number>(0);
     let selectedEvent = $derived(events[selectedEventInt]);
-    let selectedEventProject = $derived(selectedEvent ? projects.find((p) => selectedEvent.subject.includes(p.uniqueId)) : undefined)
+    let selectedEventProject = $derived(selectedEvent ? projects.find((p) => selectedEvent.subject.startsWith(p.uniqueId)) : undefined)
     let activity = $state<Activity>({} as Activity);
     let eventsDoneInt = $state<number[]>([]);
     let eventsLeftInt = $derived<number[]>(


### PR DESCRIPTION
# Description

> À la suite de #334 

Pour remettre en contexte, je vais mettre mon commentaire précédent sur ce problème : 

> (@)antoineCegepRDL ouais j'avais mis que ça détecte quand le code du projet est dans le titre de l'événement en général, et non seulement au début. J'imagine que le projet Divers (code -) est en premier et se fait détecter à cause du trait d'union qu'il y a dans le titre (voir sa capture).
> 
> Je vais alors mettre qu'il faut vraiment que ça commence avec le code du projet, et non n'importe où dans le titre.
> 
> Sinon je peux aussi faire une liste s'il en détecte plusieurs en même temps, mais le premier correctif va déjà enlever la majorité des cas d'erreur.

J'ai alors fait en sorte qu'on détecte seulement le code unique du projet selon le début du titre de l'évènement, et non dans le titre complet. Ceci était extrèmement problématique selon le cas ou le code unique d'un projet est un seul trait d'union `-`, qui est utilisé beaucoup en dehors de seulement des codes.

J'ose espérer que ceci réglera le problème en production d'Ariane et de possiblement tous les autres. Sinon, nous allons retourner voir s'il n'y aurait pas un autre problème.

# Tests

J'ai alors fait un *setup* similaire à la prod : un projet qui a `-` comme code, ainsi que d'autres codes avec et sans trait d'union.

<img width="205" height="452" alt="image" src="https://github.com/user-attachments/assets/5d31a1b2-6fd5-477a-bf5e-70f2e814b496" />

Et je me suis ajouté quelques évènements Outlook pour tester : 

<img width="382" height="178" alt="image" src="https://github.com/user-attachments/assets/c7c8aa2a-ce8b-4242-97d4-5bd3e085f82b" />

## Avant

Avec le code d'avant:

Au premier évènement, le code détecte le trait d'union en plein milieu du titre et utilise le projet `-` plutôt que celui au début du titre : 

<img width="615" height="527" alt="image" src="https://github.com/user-attachments/assets/3262ec5c-57b9-421c-8fb6-d5471a7633fb" />

Le deuxième est détecté correctement, puisque c'était déjà supposé être le projet `-` : 

<img width="615" height="527" alt="image" src="https://github.com/user-attachments/assets/f9efb292-5c40-4a75-8a7b-ebc0899b247c" />

Et le dernier est mal détecté comme le projet `-` en raison du trait d'union en plein milieu du code unique

<img width="615" height="527" alt="image" src="https://github.com/user-attachments/assets/085d39a7-da46-4a4b-bfeb-1a20f39e4010" />

## Après 

Tout est détecté comme il faut :

<img width="615" height="527" alt="image" src="https://github.com/user-attachments/assets/bca5316c-c707-47f7-896e-f66952c1b2ad" />

<img width="615" height="527" alt="image" src="https://github.com/user-attachments/assets/3078d3ab-9235-4ab6-bcb8-fe625db039f5" />

<img width="615" height="527" alt="image" src="https://github.com/user-attachments/assets/c3025d91-7728-4c94-a90b-0cf97cf6cb82" />


